### PR TITLE
feat: add scripts to generate sample types and workout names

### DIFF
--- a/HKImport/Constants.swift
+++ b/HKImport/Constants.swift
@@ -6,92 +6,351 @@ import HealthKit
 class Constants {
     static let loggingEnabled = false
 
-    static let allSampleTypes: Set<HKSampleType>? = [
-        // Body Measurements
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.height)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyFatPercentage)!,
-        // Nutrient
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryProtein)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryFatTotal)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryCarbohydrates)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryEnergyConsumed)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bloodGlucose)!,
-        // Fitness
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.stepCount)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.flightsClimbed)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.activeEnergyBurned)!,
-        HKWorkoutType.workoutType(),
-        // Category
-        HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier.sleepAnalysis)!,
-        // Heart rate
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.heartRate)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.heartRateVariabilitySDNN)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.restingHeartRate)!,
-        // Measurements
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyFatPercentage)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.height)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMass)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.leanBodyMass)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyMassIndex)!,
-        // Nutrients
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryFatTotal)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryFatPolyunsaturated)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryFatMonounsaturated)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryFatSaturated)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryCholesterol)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietarySodium)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryCarbohydrates)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryFiber)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietarySugar)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryEnergyConsumed)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryProtein)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryVitaminA)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryVitaminB6)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryVitaminB12)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryVitaminC)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryVitaminD)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryVitaminE)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryVitaminK)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryCalcium)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryIron)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryThiamin)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryRiboflavin)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryNiacin)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryFolate)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryBiotin)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryPantothenicAcid)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryPhosphorus)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryIodine)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryMagnesium)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryZinc)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietarySelenium)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryCopper)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryManganese)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryChromium)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryMolybdenum)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryChloride)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryPotassium)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryCaffeine)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryWater)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.uvExposure)!,
-        // Fitness
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.stepCount)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.distanceWalkingRunning)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.distanceCycling)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.basalEnergyBurned)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.activeEnergyBurned)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.flightsClimbed)!,
-        // Results
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.heartRate)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bodyTemperature)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bloodPressureSystolic)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bloodPressureDiastolic)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.respiratoryRate)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.basalBodyTemperature)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bloodGlucose)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.oxygenSaturation)!,
-        HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bloodAlcoholContent)!
+    static var allSampleTypes: Set<HKSampleType>? {
+        return buildAllSampleTypes()
+    }
+}
+
+// NOTE: types generated using script
+// To regenerate the types, run the following from terminal in the root of the repo:
+//   ./scripts/generate_sample_types.sh | pbcopy
+// This will fill your clipboard with generated types. Paste the result between the marks below.
+//
+// swiftlint:disable:next function_body_length cyclomatic_complexity private_over_fileprivate
+fileprivate func buildAllSampleTypes() -> Set<HKSampleType> {
+    var base: Set<HKSampleType> = [
+        HKQuantityType.workoutType()
     ]
 
+    // MARK: - BEGIN PASTE FROM SCRIPT OUTPUT
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBodyFatPercentage"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBodyMass"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBodyMassIndex"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierElectrodermalActivity"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierHeight"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierLeanBodyMass"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierWaistCircumference"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierActiveEnergyBurned"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBasalEnergyBurned"))!)
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierCrossCountrySkiingSpeed"))!)
+    }
+    if #available(iOS 17.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierCyclingCadence"))!)
+    }
+    if #available(iOS 17.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierCyclingFunctionalThresholdPower"))!)
+    }
+    if #available(iOS 17.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierCyclingPower"))!)
+    }
+    if #available(iOS 17.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierCyclingSpeed"))!)
+    }
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDistanceCrossCountrySkiing"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDistanceCycling"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDistanceDownhillSnowSports"))!)
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDistancePaddleSports"))!)
+    }
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDistanceRowing"))!)
+    }
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDistanceSkatingSports"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDistanceSwimming"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDistanceWalkingRunning"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDistanceWheelchair"))!)
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierEstimatedWorkoutEffortScore"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierFlightsClimbed"))!)
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierPaddleSportsSpeed"))!)
+    }
+    if #available(iOS 17.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierPhysicalEffort"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierPushCount"))!)
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierRowingSpeed"))!)
+    }
+    if #available(iOS 16.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierRunningPower"))!)
+    }
+    if #available(iOS 16.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierRunningSpeed"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierStepCount"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierSwimmingStrokeCount"))!)
+    if #available(iOS 16.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierUnderwaterDepth"))!)
+    }
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierWorkoutEffortScore"))!)
+    }
+    if #available(iOS 13.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierEnvironmentalAudioExposure"))!)
+    }
+    if #available(iOS 16.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierEnvironmentalSoundReduction"))!)
+    }
+    if #available(iOS 13.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierHeadphoneAudioExposure"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierHeartRate"))!)
+    if #available(iOS 16.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierHeartRateRecoveryOneMinute"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierHeartRateVariabilitySDNN"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierPeripheralPerfusionIndex"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierRestingHeartRate"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierVO2Max"))!)
+    if #available(iOS 16.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierRunningGroundContactTime"))!)
+    }
+    if #available(iOS 16.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierRunningStrideLength"))!)
+    }
+    if #available(iOS 16.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierRunningVerticalOscillation"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierSixMinuteWalkTestDistance"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierStairAscentSpeed"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierStairDescentSpeed"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierWalkingDoubleSupportPercentage"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierWalkingSpeed"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierWalkingStepLength"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryBiotin"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryCaffeine"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryCalcium"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryCarbohydrates"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryChloride"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryCholesterol"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryChromium"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryCopper"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryEnergyConsumed"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryFatMonounsaturated"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryFatPolyunsaturated"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryFatSaturated"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryFatTotal"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryFiber"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryFolate"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryIodine"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryIron"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryMagnesium"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryManganese"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryMolybdenum"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryNiacin"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryPantothenicAcid"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryPhosphorus"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryPotassium"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryProtein"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryRiboflavin"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietarySelenium"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietarySodium"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietarySugar"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryThiamin"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryVitaminA"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryVitaminB12"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryVitaminB6"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryVitaminC"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryVitaminD"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryVitaminE"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryVitaminK"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryWater"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierDietaryZinc"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBloodAlcoholContent"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBloodPressureDiastolic"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBloodPressureSystolic"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierInsulinDelivery"))!)
+    if #available(iOS 15.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierNumberOfAlcoholicBeverages"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierNumberOfTimesFallen"))!)
+    if #available(iOS 17.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierTimeInDaylight"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierUVExposure"))!)
+    if #available(iOS 16.0, *) {
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierWaterTemperature"))!)
+    }
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBasalBodyTemperature"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierForcedExpiratoryVolume1"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierForcedVitalCapacity"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierInhalerUsage"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierOxygenSaturation"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierPeakExpiratoryFlowRate"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierRespiratoryRate"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBloodGlucose"))!)
+    base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: "HKQuantityTypeIdentifierBodyTemperature"))!)
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierMindfulSession"))!)
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierHandwashingEvent"))!)
+    }
+    if #available(iOS 13.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierToothbrushingEvent"))!)
+    }
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierBleedingAfterPregnancy"))!)
+    }
+    if #available(iOS 18.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierBleedingDuringPregnancy"))!)
+    }
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierCervicalMucusQuality"))!)
+    if #available(iOS 14.3, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierContraceptive"))!)
+    }
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierIntermenstrualBleeding"))!)
+    if #available(iOS 14.3, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierLactation"))!)
+    }
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierMenstrualFlow"))!)
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierOvulationTestResult"))!)
+    if #available(iOS 14.3, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierPregnancy"))!)
+    }
+    if #available(iOS 15.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierPregnancyTestResult"))!)
+    }
+    if #available(iOS 15.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierProgesteroneTestResult"))!)
+    }
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierSexualActivity"))!)
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierSleepAnalysis"))!)
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierAbdominalCramps"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierAcne"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierAppetiteChanges"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierBladderIncontinence"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierBloating"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierBreastPain"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierChestTightnessOrPain"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierChills"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierConstipation"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierCoughing"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierDiarrhea"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierDizziness"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierDrySkin"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierFainting"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierFatigue"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierFever"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierGeneralizedBodyAche"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierHairLoss"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierHeadache"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierHeartburn"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierHotFlashes"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierLossOfSmell"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierLossOfTaste"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierLowerBackPain"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierMemoryLapse"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierMoodChanges"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierNausea"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierNightSweats"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierPelvicPain"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierRapidPoundingOrFlutteringHeartbeat"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierRunnyNose"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierShortnessOfBreath"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierSinusCongestion"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierSkippedHeartbeat"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierSleepChanges"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierSoreThroat"))!)
+    }
+    if #available(iOS 14.0, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierVaginalDryness"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierVomiting"))!)
+    }
+    if #available(iOS 13.6, *) {
+    base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: "HKCategoryTypeIdentifierWheezing"))!)
+    }
+    // MARK: - END PASTE FROM SCRIPT OUTPUT
+
+    return base
 }

--- a/HKImport/HKWorkoutActivityType+Name.swift
+++ b/HKImport/HKWorkoutActivityType+Name.swift
@@ -1,8 +1,6 @@
 import UIKit
 import HealthKit
 
-// Same parts of it are from https://stackoverflow.com/a/61140433 and
-// https://github.com/georgegreenoflondon/HKWorkoutActivityType-Descriptions/blob/master/HKWorkoutActivityType%2BDescriptions.swift
 extension HKWorkoutActivityType {
     static func activityTypeFromString(_ string: String) -> HKWorkoutActivityType {
         let  name = string.replacingOccurrences(of: "HKWorkoutActivityType", with: "")
@@ -13,206 +11,108 @@ extension HKWorkoutActivityType {
         var values: [String: Self] = [:]
         var index: UInt = 1
         while let element = self.init(rawValue: index) {
-            if element.name == "Other" {
-                break
-            } else {
-                values[element.name] = element
-                index += 1
-            }
+            values[element.name] = element
+            index += 1
+
+            if element == .other { break }
         }
         return values
     }
 
+    // NOTE: switch cases generated using script
+    // To regenerate the cases, run the following from terminal in the root of the repo:
+    //   ./scripts/generate_workout_names_mapping.sh | pbcopy
+    // This will fill your clipboard with generated cases. Paste the result between the marks below.
     var name: String {
         switch self {
-        case .americanFootball:             return "American Football"
-        case .archery:                      return "Archery"
-        case .australianFootball:           return "Australian Football"
-        case .badminton:                    return "Badminton"
-        case .baseball:                     return "Baseball"
-        case .basketball:                   return "Basketball"
-        case .bowling:                      return "Bowling"
-        case .boxing:                       return "Boxing"
-        case .climbing:                     return "Climbing"
-        case .cricket:                      return "Cricket"
-        case .crossTraining:                return "Cross Training"
-        case .curling:                      return "Curling"
-        case .cycling:                      return "Cycling"
-        case .dance:                        return "Dance"
-        case .danceInspiredTraining:        return "Dance Inspired Training"
-        case .elliptical:                   return "Elliptical"
-        case .equestrianSports:             return "Equestrian Sports"
-        case .fencing:                      return "Fencing"
-        case .fishing:                      return "Fishing"
-        case .functionalStrengthTraining:   return "Functional Strength Training"
-        case .golf:                         return "Golf"
-        case .gymnastics:                   return "Gymnastics"
-        case .handball:                     return "Handball"
-        case .hiking:                       return "Hiking"
-        case .hockey:                       return "Hockey"
-        case .hunting:                      return "Hunting"
-        case .lacrosse:                     return "Lacrosse"
-        case .martialArts:                  return "Martial Arts"
-        case .mindAndBody:                  return "Mind and Body"
-        case .mixedMetabolicCardioTraining: return "Mixed Metabolic Cardio Training"
-        case .paddleSports:                 return "Paddle Sports"
-        case .play:                         return "Play"
-        case .preparationAndRecovery:       return "Preparation and Recovery"
-        case .racquetball:                  return "Racquetball"
-        case .rowing:                       return "Rowing"
-        case .rugby:                        return "Rugby"
-        case .running:                      return "Running"
-        case .sailing:                      return "Sailing"
-        case .skatingSports:                return "Skating Sports"
-        case .snowSports:                   return "Snow Sports"
-        case .soccer:                       return "Soccer"
-        case .softball:                     return "Softball"
-        case .squash:                       return "Squash"
-        case .stairClimbing:                return "Stair Climbing"
-        case .surfingSports:                return "Surfing Sports"
-        case .swimming:                     return "Swimming"
-        case .tableTennis:                  return "Table Tennis"
-        case .tennis:                       return "Tennis"
-        case .trackAndField:                return "Track and Field"
-        case .traditionalStrengthTraining:  return "Traditional Strength Training"
-        case .volleyball:                   return "Volleyball"
-        case .walking:                      return "Walking"
-        case .waterFitness:                 return "Water Fitness"
-        case .waterPolo:                    return "Water Polo"
-        case .waterSports:                  return "Water Sports"
-        case .wrestling:                    return "Wrestling"
-        case .yoga:                         return "Yoga"
-
-        // iOS 10
-        case .barre:                        return "Barre"
-        case .coreTraining:                 return "Core Training"
-        case .crossCountrySkiing:           return "Cross Country Skiing"
-        case .downhillSkiing:               return "Downhill Skiing"
-        case .flexibility:                  return "Flexibility"
-        case .highIntensityIntervalTraining:    return "High Intensity Interval Training"
-        case .jumpRope:                     return "Jump Rope"
-        case .kickboxing:                   return "Kickboxing"
-        case .pilates:                      return "Pilates"
-        case .snowboarding:                 return "Snowboarding"
-        case .stairs:                       return "Stairs"
-        case .stepTraining:                 return "Step Training"
-        case .wheelchairWalkPace:           return "Wheelchair Walk Pace"
-        case .wheelchairRunPace:            return "Wheelchair Run Pace"
-
-        // iOS 11
-        case .taiChi:                       return "Tai Chi"
-        case .mixedCardio:                  return "Mixed Cardio"
-        case .handCycling:                  return "Hand Cycling"
-
-        // iOS 13
-        case .discSports:                   return "Disc Sports"
-        case .fitnessGaming:                return "Fitness Gaming"
-
-        // Catch-all
-        default:                            return "Other"
-        }
-    }
-
-    var associatedEmoji: String? {
-        switch self {
-        case .americanFootball:             return "🏈"
-        case .archery:                      return "🏹"
-        case .badminton:                    return "🏸"
-        case .baseball:                     return "⚾️"
-        case .basketball:                   return "🏀"
-        case .bowling:                      return "🎳"
-        case .boxing:                       return "🥊"
-        case .curling:                      return "🥌"
-        case .cycling:                      return "🚲"
-        case .equestrianSports:             return "🏇"
-        case .fencing:                      return "🤺"
-        case .fishing:                      return "🎣"
-        case .functionalStrengthTraining:   return "💪"
-        case .golf:                         return "⛳️"
-        case .hiking:                       return "🥾"
-        case .hockey:                       return "🏒"
-        case .lacrosse:                     return "🥍"
-        case .martialArts:                  return "🥋"
-        case .mixedMetabolicCardioTraining: return "❤️"
-        case .paddleSports:                 return "🛶"
-        case .rowing:                       return "🛶"
-        case .rugby:                        return "🏉"
-        case .sailing:                      return "⛵️"
-        case .skatingSports:                return "⛸"
-        case .snowSports:                   return "🛷"
-        case .soccer:                       return "⚽️"
-        case .softball:                     return "🥎"
-        case .tableTennis:                  return "🏓"
-        case .tennis:                       return "🎾"
-        case .traditionalStrengthTraining:  return "🏋️‍♂️"
-        case .volleyball:                   return "🏐"
-        case .waterFitness, .waterSports:   return "💧"
-
-        // iOS 10
-        case .barre:                        return "🥿"
-        case .crossCountrySkiing:           return "⛷"
-        case .downhillSkiing:               return "⛷"
-        case .kickboxing:                   return "🥋"
-        case .snowboarding:                 return "🏂"
-
-        // iOS 11
-        case .mixedCardio:                  return "❤️"
-
-        // iOS 13
-        case .discSports:                   return "🥏"
-        case .fitnessGaming:                return "🎮"
-
-        // Catch-all
-        default:                            return "🧍"
-        }
-    }
-
-    var associatedEmojiFemale: String? {
-        switch self {
-        case .climbing: return "🧗‍♀️"
-        case .dance, .danceInspiredTraining: return "💃"
-        case .gymnastics, .highIntensityIntervalTraining: return "🤸‍♀️"
-        case .handball: return "🤾‍♀️"
-        case .mindAndBody, .yoga, .flexibility: return "🧘‍♀️"
-        case .preparationAndRecovery: return "🙆‍♀️"
-        case .running: return "🏃‍♀️"
-        case .surfingSports: return "🏄‍♀️"
-        case .swimming: return "🏊‍♀️"
-        case .walking: return "🚶‍♀️"
-        case .waterPolo: return "🤽‍♀️"
-        case .wrestling: return "🤼‍♀️"
-
-        // Catch-all
-        default: return associatedEmoji
-        }
-    }
-
-    var associatedEmojiMale: String? {
-        switch self {
-        case .climbing: return "🧗🏻‍♂️"
-        case .dance, .danceInspiredTraining: return "🕺🏿"
-        case .gymnastics, .highIntensityIntervalTraining: return "🤸‍♂️"
-        case .handball: return "🤾‍♂️"
-        case .mindAndBody, .yoga, .flexibility: return "🧘‍♂️"
-        case .preparationAndRecovery: return "🙆‍♂️"
-        case .running: return "🏃‍♂️"
-        case .surfingSports: return "🏄‍♂️"
-        case .swimming: return "🏊‍♂️"
-        case .walking: return "🚶‍♂️"
-        case .waterPolo: return "🤽‍♂️"
-        case .wrestling: return "🤼‍♂️"
-
-        // Catch-all
-        default: return associatedEmoji
-        }
-    }
-
-    func associatedEmoji(for gender: HKBiologicalSexObject) -> String? {
-        switch gender.biologicalSex {
-        case .female: return associatedEmojiFemale
-        case .male: return associatedEmojiMale
-
-        default: return associatedEmojiMale
+            // MARK: - BEGIN PASTE FROM SCRIPT OUTPUT
+        case .americanFootball: return "AmericanFootball"
+        case .archery: return "Archery"
+        case .australianFootball: return "AustralianFootball"
+        case .badminton: return "Badminton"
+        case .baseball: return "Baseball"
+        case .basketball: return "Basketball"
+        case .bowling: return "Bowling"
+        case .boxing: return "Boxing"
+        case .climbing: return "Climbing"
+        case .cricket: return "Cricket"
+        case .crossTraining: return "CrossTraining"
+        case .curling: return "Curling"
+        case .cycling: return "Cycling"
+        case .dance: return "Dance"
+        case .danceInspiredTraining: return "DanceInspiredTraining"
+        case .elliptical: return "Elliptical"
+        case .equestrianSports: return "EquestrianSports"
+        case .fencing: return "Fencing"
+        case .fishing: return "Fishing"
+        case .functionalStrengthTraining: return "FunctionalStrengthTraining"
+        case .golf: return "Golf"
+        case .gymnastics: return "Gymnastics"
+        case .handball: return "Handball"
+        case .hiking: return "Hiking"
+        case .hockey: return "Hockey"
+        case .hunting: return "Hunting"
+        case .lacrosse: return "Lacrosse"
+        case .martialArts: return "MartialArts"
+        case .mindAndBody: return "MindAndBody"
+        case .mixedMetabolicCardioTraining: return "MixedMetabolicCardioTraining"
+        case .paddleSports: return "PaddleSports"
+        case .play: return "Play"
+        case .preparationAndRecovery: return "PreparationAndRecovery"
+        case .racquetball: return "Racquetball"
+        case .rowing: return "Rowing"
+        case .rugby: return "Rugby"
+        case .running: return "Running"
+        case .sailing: return "Sailing"
+        case .skatingSports: return "SkatingSports"
+        case .snowSports: return "SnowSports"
+        case .soccer: return "Soccer"
+        case .softball: return "Softball"
+        case .squash: return "Squash"
+        case .stairClimbing: return "StairClimbing"
+        case .surfingSports: return "SurfingSports"
+        case .swimming: return "Swimming"
+        case .tableTennis: return "TableTennis"
+        case .tennis: return "Tennis"
+        case .trackAndField: return "TrackAndField"
+        case .traditionalStrengthTraining: return "TraditionalStrengthTraining"
+        case .volleyball: return "Volleyball"
+        case .walking: return "Walking"
+        case .waterFitness: return "WaterFitness"
+        case .waterPolo: return "WaterPolo"
+        case .waterSports: return "WaterSports"
+        case .wrestling: return "Wrestling"
+        case .yoga: return "Yoga"
+        case .barre: return "Barre"
+        case .coreTraining: return "CoreTraining"
+        case .crossCountrySkiing: return "CrossCountrySkiing"
+        case .downhillSkiing: return "DownhillSkiing"
+        case .flexibility: return "Flexibility"
+        case .highIntensityIntervalTraining: return "HighIntensityIntervalTraining"
+        case .jumpRope: return "JumpRope"
+        case .kickboxing: return "Kickboxing"
+        case .pilates: return "Pilates"
+        case .snowboarding: return "Snowboarding"
+        case .stairs: return "Stairs"
+        case .stepTraining: return "StepTraining"
+        case .wheelchairWalkPace: return "WheelchairWalkPace"
+        case .wheelchairRunPace: return "WheelchairRunPace"
+        case .taiChi: return "TaiChi"
+        case .mixedCardio: return "MixedCardio"
+        case .handCycling: return "HandCycling"
+        case .discSports: return "DiscSports"
+        case .fitnessGaming: return "FitnessGaming"
+        case .cardioDance: return "CardioDance"
+        case .socialDance: return "SocialDance"
+        case .pickleball: return "Pickleball"
+        case .cooldown: return "Cooldown"
+        case .swimBikeRun: return "SwimBikeRun"
+        case .transition: return "Transition"
+        case .underwaterDiving: return "UnderwaterDiving"
+        case .other: return "Other"
+            // MARK: - END PASTE FROM SCRIPT OUTPUT
+        default:
+            return "Other"
         }
     }
 }

--- a/HKImport/Importer.swift
+++ b/HKImport/Importer.swift
@@ -211,7 +211,9 @@ class Importer: NSObject, XMLParserDelegate {
     func saveRecord(item: HealthRecord, withSuccess successBlock: @escaping () -> Void, failure failureBlock: @escaping () -> Void) {
         // HealthKit raises an exception if time between end and start date is > 345600
         let duration = item.endDate.timeIntervalSince(item.startDate)
-        if duration > 345600 || (item.type == "HKQuantityTypeIdentifierHeadphoneAudioExposure" && duration < 0.001) {
+        if duration > 345600 ||
+            (item.type == "HKQuantityTypeIdentifierHeadphoneAudioExposure" && duration < 0.001) ||
+            (item.type == "HKCategoryTypeIdentifierAudioExposureEvent" && Int(item.value) == 0) {
             failureBlock()
             return
         }

--- a/HKImportTests/HKWorkoutActivity+NameTests.swift
+++ b/HKImportTests/HKWorkoutActivity+NameTests.swift
@@ -1,0 +1,26 @@
+//
+//  HKWorkoutActivity+NameTests.swift
+//  HKImport
+//
+//  Created by Jon Carl on 1/1/25.
+//  Copyright © 2025 boaz saragossi. All rights reserved.
+//
+
+import Testing
+@testable import HKImport
+import HealthKit
+
+struct HKWorkoutActivityNameTests {
+    @Test func basicWorkout() async throws {
+        let workout = HKWorkoutActivityType.activityTypeFromString("HKWorkoutActivityTypeRunning")
+
+        #expect(workout == .running)
+    }
+
+    @Test func workoutWithMultipleWords() async throws {
+        let workout = HKWorkoutActivityType.activityTypeFromString("HKWorkoutActivityTypeCrossTraining")
+
+        #expect(workout == .crossTraining)
+    }
+
+}

--- a/scripts/generate_sample_types.sh
+++ b/scripts/generate_sample_types.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# use macosx as everyone should have it by default
+SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
+HEADER_PATH="$SDK_PATH/System/Library/Frameworks/HealthKit.framework/Versions/Current/Headers/HKTypeIdentifiers.h"
+
+# NOTE: there is not an easy way to get this so it's hard coded
+BUILD_TARGET_IOS_VERSION=12.0
+
+if [ ! -f "$HEADER_PATH" ]; then
+    echo "HealthKit header file not found at $HEADER_PATH"
+    exit 1
+fi
+
+ios_avail_regex="API_AVAILABLE\(ios\(([0-9]+\.[0-9]+)\)"
+
+ignore_identifiers=(
+    # forbidden to write by apple
+    "HKCategoryTypeIdentifierHeadphoneAudioExposureEvent"
+    "HKQuantityTypeIdentifierAppleExerciseTime"
+    "HKQuantityTypeIdentifierAtrialFibrillationBurden"
+    "HKCategoryTypeIdentifierAppleWalkingSteadinessEvent"
+    "HKCategoryTypeIdentifierIrregularHeartRhythmEvent"
+    "HKQuantityTypeIdentifierAppleMoveTime"
+    "HKQuantityTypeIdentifierWalkingHeartRateAverage"
+    "HKCategoryTypeIdentifierHighHeartRateEvent"
+    "HKCategoryTypeIdentifierLowHeartRateEvent"
+    "HKQuantityTypeIdentifierNikeFuel"
+    "HKCategoryTypeIdentifierSleepApneaEvent"
+    "HKCategoryTypeIdentifierPersistentIntermenstrualBleeding"
+    "HKCategoryTypeIdentifierLowCardioFitnessEvent"
+    "HKQuantityTypeIdentifierAppleStandTime"
+    "HKQuantityTypeIdentifierAppleWalkingSteadiness"
+    "HKQuantityTypeIdentifierAppleSleepingWristTemperature"
+    "HKCategoryTypeIdentifierAudioExposureEvent"
+    "HKCategoryTypeIdentifierAppleStandHour"
+    "HKQuantityTypeIdentifierWalkingAsymmetryPercentage"
+    "HKCategoryTypeIdentifierProlongedMenstrualPeriods"
+    "HKCategoryTypeIdentifierIrregularMenstrualCycles"
+    "HKCategoryTypeIdentifierInfrequentMenstrualCycles"
+    "HKQuantityTypeIdentifierAppleSleepingBreathingDisturbances"
+    "HKCategoryTypeIdentifierEnvironmentalAudioExposureEvent"
+    "HKCategoryTypeIdentifierAudioExposureEvent"
+)
+
+grep -E "HKQuantityTypeIdentifier[A-Za-z0-9]+" "$HEADER_PATH" | grep -v "API_DEPRECATED" | \
+    while read -r line; do
+        identifier=$(echo "$line" | grep -oE "HKQuantityTypeIdentifier[A-Za-z0-9]+")
+        if [[ "${ignore_identifiers[*]}" =~ $identifier ]]; then
+            continue
+        fi
+        if [[ $line =~ $ios_avail_regex ]]; then
+            ios_version="${BASH_REMATCH[1]}"
+            if (( $(echo "$ios_version > $BUILD_TARGET_IOS_VERSION" | bc -l) )); then
+                echo "if #available(iOS $ios_version, *) {"
+            fi
+        fi
+
+        echo "base.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier(rawValue: \"$identifier\"))!)"
+        if [[ $line =~ $ios_avail_regex ]]; then
+            ios_version="${BASH_REMATCH[1]}"
+            if (( $(echo "$ios_version > $BUILD_TARGET_IOS_VERSION" | bc -l) )); then
+                echo "}"
+            fi
+        fi
+    done
+
+grep -E "HKCategoryTypeIdentifier[A-Za-z0-9]+" "$HEADER_PATH" | grep -v "API_DEPRECATED" | \
+    while read -r line; do
+        identifier=$(echo "$line" | grep -oE "HKCategoryTypeIdentifier[A-Za-z0-9]+")
+        if [[ "${ignore_identifiers[*]}" =~ $identifier ]]; then
+            continue
+        fi
+        if [[ $line =~ $ios_avail_regex ]]; then
+            ios_version="${BASH_REMATCH[1]}"
+            if (( $(echo "$ios_version > $BUILD_TARGET_IOS_VERSION" | bc -l) )); then
+                echo "if #available(iOS $ios_version, *) {"
+            fi
+        fi
+
+        echo "base.insert(HKQuantityType.categoryType(forIdentifier: HKCategoryTypeIdentifier(rawValue: \"$identifier\"))!)"
+        if [[ $line =~ $ios_avail_regex ]]; then
+            ios_version="${BASH_REMATCH[1]}"
+            if (( $(echo "$ios_version > $BUILD_TARGET_IOS_VERSION" | bc -l) )); then
+                echo "}"
+            fi
+        fi
+    done

--- a/scripts/generate_workout_names_mapping.sh
+++ b/scripts/generate_workout_names_mapping.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# use macosx as everyone should have it by default
+SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
+HEADER_PATH="$SDK_PATH/System/Library/Frameworks/HealthKit.framework/Versions/Current/Headers/HKWorkout.h"
+
+if [ ! -f "$HEADER_PATH" ]; then
+    echo "HealthKit header file not found at $HEADER_PATH"
+    exit 1
+fi
+
+grep -E "HKWorkoutActivityType[A-Za-z]+" "$HEADER_PATH" | \
+    awk '{print $1}' | \
+    sed -E 's/,?$//' | \
+    sed 's/HKWorkoutActivityType//g' | \
+    while read -r caseName; do
+        l=$(echo "$caseName" | sed -E 's/^(.)/\L\1/')
+        echo "case .$l: return \"$caseName\""
+    done


### PR DESCRIPTION
As iOS versions release there are new workouts and sample types available in HealthKit. This PR adds two scripts to automatically generate code for sample types and workouts.

By generating sample types we will support all sample types instead of sample types manually added. While doing this I discovered some sample types which Apple does not allow you to import so those are excluded.

By generating workout types all the newest workout types are supported. I also discovered that workouts with compound names were not correctly supported in the current version of the project. Example: importing a `Cross Training` workout didn't work correctly as it's called `CrossTraining` in the xml. This is fixed using the generated code and I added a test case as well.

I discovered that if you import a `HKCategoryTypeIdentifierAudioExposureEvent` with the value of 0 HealthKit will error out. I added code so as to avoid that.