### PR TITLE
fix: skip duplicate records nested inside correlations

### DIFF
--- a/HKImport/Importer.swift
+++ b/HKImport/Importer.swift
@@ -69,6 +69,7 @@ class Importer: NSObject, XMLParserDelegate {
     var allSamples: [HKSample] = []
     var authorizedTypes: [HKSampleType: Bool] = [:]
     var readCount = 0
+    var insideCorrelation = false
     var currentRecord: HealthRecord = HealthRecord.init()
     var readCounterLabel: UILabel?
     var writeCounterLabel: UILabel?
@@ -94,9 +95,15 @@ class Importer: NSObject, XMLParserDelegate {
     }
 
     func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String: String]) {
+        if elementName == "Correlation" {
+            insideCorrelation = true
+            return
+        }
         if elementName == "Record" {
+            guard !insideCorrelation else { return }
             parseRecordFromAttributes(attributeDict)
         } else if elementName == "MetadataEntry" {
+            guard !insideCorrelation else { return }
             parseMetaDataFromAttributes(attributeDict)
         } else if elementName == "Workout" {
             parseWorkoutFromAttributes(attributeDict)
@@ -200,6 +207,11 @@ class Importer: NSObject, XMLParserDelegate {
     }
 
     func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
+        if elementName == "Correlation" {
+            insideCorrelation = false
+            return
+        }
+        if insideCorrelation { return }
         if elementName == "Record" || elementName == "Workout" {
             readCount += 1
             if Constants.loggingEnabled {

--- a/HKImportTests/HKImportTests.swift
+++ b/HKImportTests/HKImportTests.swift
@@ -229,4 +229,40 @@ struct HKImportTests {
         #expect(metadata[HKMetadataKeyDateOfEarliestDataUsedForEstimate] as? Date == expectedMetadataDate)
         #expect(metadata[HKMetadataKeyAppleDeviceCalibrated] as? Int == 1)
     }
+
+    @Test func correlation_nested_records_are_skipped() async throws {
+        // Apple's HealthKit export duplicates correlated records: each <Record> inside a
+        // <Correlation> also appears as a top-level <Record>. We must only import the
+        // top-level copy to avoid duplicates.
+        let xmlString = """
+<?xml version="1.0" encoding="UTF-8"?>
+<HealthData locale="en_US">
+ <Correlation type="HKCorrelationTypeIdentifierFood" sourceName="Testing" creationDate="2024-12-23 19:38:40 -0600" startDate="2024-12-23 19:00:00 -0600" endDate="2024-12-23 19:00:00 -0600">
+  <MetadataEntry key="HKFoodType" value="Should be ignored"/>
+  <Record type="HKQuantityTypeIdentifierDietaryFatSaturated" sourceName="Testing" unit="g" creationDate="2024-12-23 19:38:40 -0600" startDate="2024-12-23 19:00:00 -0600" endDate="2024-12-23 19:00:00 -0600" value="2.91379">
+   <MetadataEntry key="HKFoodBrandName" value="Should be ignored"/>
+  </Record>
+ </Correlation>
+ <Record type="HKQuantityTypeIdentifierDietaryFatSaturated" sourceName="Testing" unit="g" creationDate="2024-12-23 19:38:40 -0600" startDate="2024-12-23 19:00:00 -0600" endDate="2024-12-23 19:00:00 -0600" value="2.91379">
+  <MetadataEntry key="HKFoodBrandName" value="13 Chips"/>
+ </Record>
+</HealthData>
+"""
+        let importer = Importer()
+        importer.authorizedTypes = [HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.dietaryFatSaturated)!: true]
+
+        let parser = XMLParser(data: xmlString.data(using: .utf8)!)
+        parser.delegate = importer
+        parser.parse()
+
+        // Only the top-level Record should be imported, not the one nested in <Correlation>.
+        try #require(importer.allSamples.count == 1)
+
+        // swiftlint:disable:next force_cast
+        let sample = importer.allSamples[0] as! HKQuantitySample
+        let metadata = sample.metadata!
+
+        // The imported sample should have the top-level record's metadata, not the nested one.
+        #expect(metadata["HKFoodBrandName"] as? String == "13 Chips")
+    }
 }


### PR DESCRIPTION
## Problem

Apple's HealthKit export includes every record that belongs to a `<Correlation>` (e.g., food/nutrition entries) in two places: once as a child of the `<Correlation>` element, and again as a top-level `<Record>`. The export XML documents this explicitly in the DTD:

> *"Any Records that appear as children of a correlation also appear as top-level records in this document."*

HKImport imports both copies, resulting in duplicate data in HealthKit — visible as doubled nutritional values in apps like MacroFactor.

## Solution

Track whether the XML parser is inside a `<Correlation>` element and skip all nested `<Record>` and `<MetadataEntry>` elements — both parsing (`didStartElement`) and saving (`didEndElement`). The top-level copies are still imported normally, so:

- **No data is lost** — every record is still imported exactly once
- **Source identity is preserved** — the top-level records carry the full `sourceName`, `sourceVersion`, and `device` attributes, so device/source preservation (#146) continues to work correctly
- **No nil-device crash** — the correlation-nested records can lack device info; by skipping them entirely we avoid the `HKDevice` "at least one field must be non-nil" exception without needing a defensive nil guard

### What's included

- `insideCorrelation` flag in `Importer` to track parser depth
- Guards in both `didStartElement` and `didEndElement` to skip nested records completely